### PR TITLE
[DEBUG] Updated version of CEPReloader

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -23,12 +23,6 @@ function init() {
 
             router.get('/' + key, function (req, res) {
 
-                // Special code for faster debugging
-                if (key === "kill") {
-                    res.json({message: 'ok.'});
-                    csInterface.closeExtension();
-                }
-
                 // Count request query parameters
                 let propertyCount = 0;
                 for (const propName in req.query) {
@@ -59,6 +53,14 @@ function init() {
             });
         }
     }
+
+    // Special code for faster debugging
+    csInterface.addEventListener(csInterface.getExtensionID(), function(event) {
+        let confirmEvent = new CSEvent(event.extensionId, event.scope, csInterface.getApplicationID(), csInterface.getExtensionID());
+        confirmEvent.data = 'ok';
+        csInterface.dispatchEvent(confirmEvent);
+        csInterface.closeExtension();
+    });
 
     // Start server
     app.use('/', router);

--- a/host/index.jsx
+++ b/host/index.jsx
@@ -3,11 +3,6 @@
  */
 var host = {
     /**
-     * This method is only there for debugging purposes.
-     */
-    kill: function () {
-    },
-    /**
      * Mutes an audio track of the active sequence.
      * @param trackNumber the 0 based audio track number
      */


### PR DESCRIPTION
My new Version of CEPReloader now utilizes events instead of communicating with REST endpoints.
This is because...

1. The code before was really ugly and hacky
2. not every CEP extension has rest built into it, but it sure does have events

This is just a safer and less tedious way of reloading the extension which I strongly advise you to use.
(Of course you can keep the old code as the older version of CEPReloader still works just fine, but I plan on adding new features and those kind of require this change and I like to offer my reloader to everyone who develops CEP extensions as well)